### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/Auth/2_ServerlessAPI/ServerlessBackend.yaml
+++ b/Auth/2_ServerlessAPI/ServerlessBackend.yaml
@@ -55,7 +55,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       FunctionName: RequestUnicorn
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Role: !GetAtt RequestUnicornExecutionRole.Arn
       Timeout: 5
       MemorySize: 128

--- a/DevOps/1_ServerlessApplicationModel/uni-api/template.yml
+++ b/DevOps/1_ServerlessApplicationModel/uni-api/template.yml
@@ -23,7 +23,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       FunctionName: 'uni-api-list'
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       CodeUri: app
       Handler: list.lambda_handler
       Description: List Unicorns

--- a/DevOps/2_ContinuousDeliveryPipeline/uni-api/template.yml
+++ b/DevOps/2_ContinuousDeliveryPipeline/uni-api/template.yml
@@ -30,7 +30,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       FunctionName: 'uni-api-read'
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       CodeUri: app
       Handler: read.lambda_handler
       Description: View Unicorn by name
@@ -50,7 +50,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       FunctionName: 'uni-api-list'
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       CodeUri: app
       Handler: list.lambda_handler
       Description: List Unicorns

--- a/DevOps/3_XRay/uni-api/template.yml
+++ b/DevOps/3_XRay/uni-api/template.yml
@@ -30,7 +30,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       FunctionName: 'uni-api-read'
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       CodeUri: app
       Handler: read.lambda_handler
       Description: View Unicorn by name
@@ -51,7 +51,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       FunctionName: 'uni-api-list'
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       CodeUri: app
       Handler: list.lambda_handler
       Description: List Unicorns
@@ -72,7 +72,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       FunctionName: 'uni-api-update'
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       CodeUri: app
       Handler: update.lambda_handler
       Description: Update Unicorn
@@ -93,7 +93,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       FunctionName: 'uni-api-delete'
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       CodeUri: app
       Handler: delete.lambda_handler
       Description: Delete Unicorn

--- a/DevOps/4_MultipleEnvironments/uni-api/template.yml
+++ b/DevOps/4_MultipleEnvironments/uni-api/template.yml
@@ -34,7 +34,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       FunctionName: !Sub 'uni-api-read${CustomSuffix}'
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       CodeUri: app
       Handler: read.lambda_handler
       Description: View Unicorn by name
@@ -54,7 +54,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       FunctionName: !Sub 'uni-api-list${CustomSuffix}'
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       CodeUri: app
       Handler: list.lambda_handler
       Description: List Unicorns
@@ -74,7 +74,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       FunctionName: !Sub 'uni-api-update${CustomSuffix}'
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       CodeUri: app
       Handler: update.lambda_handler
       Description: Update Unicorn
@@ -94,7 +94,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       FunctionName: !Sub 'uni-api-remove${CustomSuffix}'
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       CodeUri: app
       Handler: delete.lambda_handler
       Description: Remove Unicorn

--- a/DevOps/4_MultipleEnvironments/uni-api/test-template.yml
+++ b/DevOps/4_MultipleEnvironments/uni-api/test-template.yml
@@ -22,7 +22,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: uni-api-test-setup
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       CodeUri: int-test/
       Handler: setup.lambda_handler
       Description: Setup integration test
@@ -36,7 +36,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: uni-api-test
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       CodeUri: int-test/
       Handler: test.lambda_handler
       Description: Execute integration test

--- a/ImageProcessing/src/cloudformation/module-setup.yaml
+++ b/ImageProcessing/src/cloudformation/module-setup.yaml
@@ -76,7 +76,7 @@ Resources:
     Properties:
       Description: "Use Amazon Rekognition to detect faces"
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       MemorySize: 256
       Timeout: 60
       Policies:
@@ -101,7 +101,7 @@ Resources:
     Properties:
       Description: "mock notification sender"
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       MemorySize: 256
       Timeout: 60
       CodeUri:
@@ -112,7 +112,7 @@ Resources:
     Properties:
       Description: "Use Amazon Rekognition to check if the face is already in the collection"
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       MemorySize: 256
       Timeout: 60
       Policies:
@@ -139,7 +139,7 @@ Resources:
     Properties:
       Description: "Index the photo into Rekognition collection"
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       MemorySize: 256
       Timeout: 60
       Policies:
@@ -167,7 +167,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       MemorySize: 1536
       Timeout: 300
       Policies:
@@ -195,7 +195,7 @@ Resources:
     Properties:
       Description: "Save metadata of the photo to DynamoDB table"
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       MemorySize: 256
       Timeout: 60
       Environment:

--- a/MultiRegion/1_API/wild-rydes-api-failover-region.yaml
+++ b/MultiRegion/1_API/wild-rydes-api-failover-region.yaml
@@ -100,7 +100,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: tickets-get.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       FunctionName: TicketGetFunction
       Policies:
         - AWSLambdaDynamoDBExecutionRole #managed policy
@@ -126,7 +126,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: tickets-post.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       FunctionName: TicketPostFunction
       Policies:
         - AWSLambdaDynamoDBExecutionRole #managed policy
@@ -151,7 +151,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: health-check.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       FunctionName: SXRHealthCheckFunction
       Policies:
         - AWSLambdaDynamoDBExecutionRole #managed policy

--- a/MultiRegion/1_API/wild-rydes-api-primary-region.yaml
+++ b/MultiRegion/1_API/wild-rydes-api-primary-region.yaml
@@ -100,7 +100,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: tickets-get.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       FunctionName: TicketGetFunction
       Policies:
         - AWSLambdaDynamoDBExecutionRole #managed policy
@@ -126,7 +126,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: tickets-post.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       FunctionName: TicketPostFunction
       Policies:
         - AWSLambdaDynamoDBExecutionRole #managed policy
@@ -151,7 +151,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: health-check.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       FunctionName: SXRHealthCheckFunction
       Policies:
         - AWSLambdaDynamoDBExecutionRole #managed policy

--- a/WebApplication/5_OAuth/prerequisites.yaml
+++ b/WebApplication/5_OAuth/prerequisites.yaml
@@ -370,7 +370,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       FunctionName: RequestUnicorn
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Role: !GetAtt RequestUnicornExecutionRole.Arn
       Timeout: 5
       MemorySize: 128


### PR DESCRIPTION
CloudFormation templates in aws-serverless-workshops-kr have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.